### PR TITLE
Fix for issue #5 - don't require a connection where it's not needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
   <packaging>pom</packaging>
   <properties>
       <teamcity-version>2020.1</teamcity-version>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <repositories>
     <repository>

--- a/teamcity-agent/pom.xml
+++ b/teamcity-agent/pom.xml
@@ -43,9 +43,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <configuration>
-          <source>7</source>
-          <target>7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/teamcity-agent/src/main/java/com/cyberark/agent/ConjurEnvParameterReplacer.java
+++ b/teamcity-agent/src/main/java/com/cyberark/agent/ConjurEnvParameterReplacer.java
@@ -4,19 +4,21 @@ import com.cyberark.common.*;
 import com.cyberark.common.exceptions.ConjurApiAuthenticateException;
 import com.cyberark.common.exceptions.MissingMandatoryParameterException;
 import jetbrains.buildServer.BuildProblemData;
-import jetbrains.buildServer.agent.*;
+import jetbrains.buildServer.agent.AgentLifeCycleAdapter;
+import jetbrains.buildServer.agent.AgentLifeCycleListener;
+import jetbrains.buildServer.agent.AgentRunningBuild;
+import jetbrains.buildServer.agent.BuildProgressLogger;
 import jetbrains.buildServer.util.EventDispatcher;
 import jetbrains.buildServer.util.ssl.SSLTrustStoreProvider;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ConjurBuildFeature extends AgentLifeCycleAdapter {
+public class ConjurEnvParameterReplacer extends AgentLifeCycleAdapter {
     public EventDispatcher<AgentLifeCycleListener> dispatcher;
     public SSLTrustStoreProvider trustStoreProvider;
 
-    public ConjurBuildFeature(EventDispatcher<AgentLifeCycleListener> dispatcher, SSLTrustStoreProvider trustStoreProvider) {
+    public ConjurEnvParameterReplacer(EventDispatcher<AgentLifeCycleListener> dispatcher, SSLTrustStoreProvider trustStoreProvider) {
         this.dispatcher = dispatcher;
         this.trustStoreProvider = trustStoreProvider;
         this.dispatcher.addListener(this);
@@ -142,7 +144,7 @@ public class ConjurBuildFeature extends AgentLifeCycleAdapter {
         // TODO: Currently this is only going to set the conjur parameter as an environment variables
         //   this may be undesirable for users of this plugin when they are trying to set `system` or `config` parameters
         for (Map.Entry<String, String> kv : conjurVariables.entrySet()) {
-            String envVar = kv.getKey().substring(4, kv.getKey().length());
+            String envVar = kv.getKey().substring(4); // the '4' means after the "env." prefix
             logger.Verbose(String.format("Setting secret '%s' with id '%s'", envVar, kv.getKey()));
             runningBuild.addSharedEnvironmentVariable(envVar, kv.getValue());
             runningBuild.getPasswordReplacer().addPassword(kv.getValue());

--- a/teamcity-agent/src/main/java/com/cyberark/agent/ConjurEnvParameterReplacer.java
+++ b/teamcity-agent/src/main/java/com/cyberark/agent/ConjurEnvParameterReplacer.java
@@ -62,25 +62,9 @@ public class ConjurEnvParameterReplacer extends AgentLifeCycleAdapter {
     @Override
     public void buildStarted(AgentRunningBuild runningBuild) {
         BuildProgressLogger buildLogger = runningBuild.getBuildLogger();
-        ConjurConnectionParameters conjurConfig = new ConjurConnectionParameters(runningBuild.getSharedConfigParameters(), true);
-        LogUtil logger = new LogUtil(buildLogger, conjurConfig.getVerboseLogging());
 
-        ConjurConfig config = null;
-        try {
-            config = new ConjurConfig(
-                    conjurConfig.getApplianceUrl(),
-                    conjurConfig.getAccount(),
-                    conjurConfig.getAuthnLogin(),
-                    conjurConfig.getApiKey(),
-                    null,
-                    conjurConfig.getCertFile());
-        } catch (MissingMandatoryParameterException e) {
-            String message = String.format("ERROR: Retrieving conjur agent's shared parameters. %s", e.getMessage());
-            buildLogger.logBuildProblem(
-                    BuildProblemData.createBuildProblem(
-                            "ConjurConnection", "ConjurConnection", message));
-            runningBuild.stopBuild(message);
-        }
+        ConjurConnectionParameters conjurConnParams = new ConjurConnectionParameters(runningBuild.getSharedConfigParameters(), true);
+        LogUtil logger = new LogUtil(buildLogger, conjurConnParams.getVerboseLogging());
 
         Map<String, String> buildParams = runningBuild.getSharedBuildParameters().getAllParameters();
         Map<String, String> conjurVariables = getVariableIdsFromBuildParameters(buildParams);
@@ -88,8 +72,25 @@ public class ConjurEnvParameterReplacer extends AgentLifeCycleAdapter {
         if (conjurVariables.size() == 0) {
             logger.Verbose("No conjur variables were found within the shared build parameters.");
             // No conjur variables are present in the build parameters, if this is the case lets not attempt to
-            // authenticate and just return
+            // neither read the connection parameters nor authenticate and just return
             return;
+        }
+
+        ConjurConfig config = null;
+        try {
+            config = new ConjurConfig(
+                    conjurConnParams.getApplianceUrl(),
+                    conjurConnParams.getAccount(),
+                    conjurConnParams.getAuthnLogin(),
+                    conjurConnParams.getApiKey(),
+                    null,
+                    conjurConnParams.getCertFile());
+        } catch (MissingMandatoryParameterException e) {
+            String message = String.format("ERROR: Retrieving conjur agent's shared parameters. %s", e.getMessage());
+            buildLogger.logBuildProblem(
+                    BuildProblemData.createBuildProblem(
+                            "ConjurConnection", "ConjurConnection", message));
+            runningBuild.stopBuild(message);
         }
 
         ConjurApi client = new ConjurApi(config);
@@ -101,7 +102,7 @@ public class ConjurEnvParameterReplacer extends AgentLifeCycleAdapter {
             for (Map.Entry<String, String> kv : conjurVariables.entrySet()) {
                 logger.Verbose(String.format("Attempting to retrieve secret '%s' with id '%s'", kv.getKey(), kv.getValue()));
                 HttpResponse response = client.getSecret(kv.getValue());
-                if (response.statusCode != 200 && conjurConfig.getFailOnError()) {
+                if (response.statusCode != 200 && conjurConnParams.getFailOnError()) {
                     String message = String.format("ERROR: Retrieving secret '%s' from conjur. Received status code '%d'",
                             kv.getValue(), response.statusCode);
                     buildLogger.logBuildProblem(
@@ -114,7 +115,7 @@ public class ConjurEnvParameterReplacer extends AgentLifeCycleAdapter {
             }
 
         } catch (ConjurApiAuthenticateException e) {
-            if (!conjurConfig.getFailOnError()) {
+            if (!conjurConnParams.getFailOnError()) {
                 // Failed to authenticate but no fail on error, do not set running build parameters
                 return;
             }
@@ -130,7 +131,7 @@ public class ConjurEnvParameterReplacer extends AgentLifeCycleAdapter {
                             "ConjurConnection", "ConjurConnection", message));
             runningBuild.stopBuild(message);
         } catch (Exception e) {
-            if (!conjurConfig.getFailOnError()) {
+            if (!conjurConnParams.getFailOnError()) {
                 return;
             }
             String message = String.format("ERROR: Generic error returned when establishing connection to conjur. %s", e.getMessage());

--- a/teamcity-agent/src/main/resources/META-INF/build-agent-plugin.xml
+++ b/teamcity-agent/src/main/resources/META-INF/build-agent-plugin.xml
@@ -4,5 +4,5 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd"
        default-autowire="constructor">
-    <bean id="conjurBuildFeature" class="com.cyberark.agent.ConjurBuildFeature"/>
+    <bean id="conjurEnvParameterReplacer" class="com.cyberark.agent.ConjurEnvParameterReplacer"/>
 </beans>

--- a/teamcity-common/pom.xml
+++ b/teamcity-common/pom.xml
@@ -22,9 +22,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/teamcity-common/src/main/java/com/cyberark/common/ConjurConnectionParameters.java
+++ b/teamcity-common/src/main/java/com/cyberark/common/ConjurConnectionParameters.java
@@ -43,7 +43,7 @@ public class ConjurConnectionParameters {
         sharedParameters.put(prefix + conjurKeys.getAccount(), this.getAccount());
         sharedParameters.put(prefix + conjurKeys.getApplianceUrl(), this.getApplianceUrl());
         sharedParameters.put(prefix + conjurKeys.getAuthnLogin(), this.getAuthnLogin());
-        sharedParameters.put(prefix + conjurKeys.getApiKey(), this.getApiKey());
+        sharedParameters.put(prefix + conjurKeys.getApiKey(), this.getApiKey()); // TODO !!! this must be added as a password-type param instead, or must not be added at all
         sharedParameters.put(prefix + conjurKeys.getCertFile(), this.getCertFile());
         sharedParameters.put(prefix + conjurKeys.getFailOnError(), String.valueOf(this.getFailOnError()));
         sharedParameters.put(prefix + conjurKeys.getVerboseLogging(), String.valueOf(this.getVerboseLogging()));

--- a/teamcity-common/src/main/java/com/cyberark/common/ConjurConnectionParameters.java
+++ b/teamcity-common/src/main/java/com/cyberark/common/ConjurConnectionParameters.java
@@ -14,45 +14,31 @@ public class ConjurConnectionParameters {
     private String failOnError;
     private String verboseLogging;
     private static final ConjurJspKey conjurKeys = new ConjurJspKey();
-
-    public ConjurConnectionParameters(Map<String, String> parameters) {
-        this.apiKey = parameters.get(conjurKeys.getApiKey());
-        this.applianceUrl = parameters.get(conjurKeys.getApplianceUrl());
-        this.authnLogin = parameters.get(conjurKeys.getAuthnLogin());
-        this.account = parameters.get(conjurKeys.getAccount());
-        this.certFile = parameters.get(conjurKeys.getCertFile());
-        this.failOnError = parameters.get(conjurKeys.getFailOnError());
-        this.verboseLogging = parameters.get(conjurKeys.getVerboseLogging()) ;
-    }
+    private static final String agentParameterPrefix = "teamcity.conjur.";
 
     public ConjurConnectionParameters(Map<String, String> parameters, boolean agentSide) {
-        String agentParameterPrefix = getAgentParameterPrefix();
-        this.apiKey = parameters.get(agentParameterPrefix + conjurKeys.getApiKey());
-        this.applianceUrl = parameters.get(agentParameterPrefix + conjurKeys.getApplianceUrl());
-        this.authnLogin = parameters.get(agentParameterPrefix + conjurKeys.getAuthnLogin());
-        this.account = parameters.get(agentParameterPrefix + conjurKeys.getAccount());
-        this.certFile = parameters.get(agentParameterPrefix + conjurKeys.getCertFile());
-        this.failOnError = parameters.get(agentParameterPrefix + conjurKeys.getFailOnError());
-        this.verboseLogging = parameters.get(agentParameterPrefix + conjurKeys.getVerboseLogging());
+        String prefix = agentSide ? agentParameterPrefix : "";
+        this.apiKey = parameters.get(prefix + conjurKeys.getApiKey());
+        this.applianceUrl = parameters.get(prefix + conjurKeys.getApplianceUrl());
+        this.authnLogin = parameters.get(prefix + conjurKeys.getAuthnLogin());
+        this.account = parameters.get(prefix + conjurKeys.getAccount());
+        this.certFile = parameters.get(prefix + conjurKeys.getCertFile());
+        this.failOnError = parameters.get(prefix + conjurKeys.getFailOnError());
+        this.verboseLogging = parameters.get(prefix + conjurKeys.getVerboseLogging());
     }
 
     public Map<String, String> getAgentSharedParameters() throws MissingMandatoryParameterException {
         HashMap<String, String> sharedParameters = new HashMap<String, String>();
-        String prefix = getAgentParameterPrefix();
 
-        sharedParameters.put(prefix + conjurKeys.getAccount(), this.getAccount());
-        sharedParameters.put(prefix + conjurKeys.getApplianceUrl(), this.getApplianceUrl());
-        sharedParameters.put(prefix + conjurKeys.getAuthnLogin(), this.getAuthnLogin());
-        sharedParameters.put(prefix + conjurKeys.getApiKey(), this.getApiKey()); // TODO !!! this must be added as a password-type param instead, or must not be added at all
-        sharedParameters.put(prefix + conjurKeys.getCertFile(), this.getCertFile());
-        sharedParameters.put(prefix + conjurKeys.getFailOnError(), String.valueOf(this.getFailOnError()));
-        sharedParameters.put(prefix + conjurKeys.getVerboseLogging(), String.valueOf(this.getVerboseLogging()));
+        sharedParameters.put(agentParameterPrefix + conjurKeys.getAccount(), this.getAccount());
+        sharedParameters.put(agentParameterPrefix + conjurKeys.getApplianceUrl(), this.getApplianceUrl());
+        sharedParameters.put(agentParameterPrefix + conjurKeys.getAuthnLogin(), this.getAuthnLogin());
+        sharedParameters.put(agentParameterPrefix + conjurKeys.getApiKey(), this.getApiKey()); // TODO !!! this must be added as a password-type param instead, or must not be added at all
+        sharedParameters.put(agentParameterPrefix + conjurKeys.getCertFile(), this.getCertFile());
+        sharedParameters.put(agentParameterPrefix + conjurKeys.getFailOnError(), String.valueOf(this.getFailOnError()));
+        sharedParameters.put(agentParameterPrefix + conjurKeys.getVerboseLogging(), String.valueOf(this.getVerboseLogging()));
 
         return sharedParameters;
-    }
-
-    public static String getAgentParameterPrefix() {
-        return "teamcity.conjur.";
     }
 
     @Override

--- a/teamcity-common/src/main/java/com/cyberark/common/ConjurConnectionParameters.java
+++ b/teamcity-common/src/main/java/com/cyberark/common/ConjurConnectionParameters.java
@@ -1,7 +1,6 @@
 package com.cyberark.common;
 
 import com.cyberark.common.exceptions.MissingMandatoryParameterException;
-import com.sun.org.apache.xpath.internal.operations.Bool;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/teamcity-server/pom.xml
+++ b/teamcity-server/pom.xml
@@ -52,6 +52,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>

--- a/teamcity-server/src/main/java/com/cyberark/server/ConjurBuildStartContextProcessor.java
+++ b/teamcity-server/src/main/java/com/cyberark/server/ConjurBuildStartContextProcessor.java
@@ -69,16 +69,16 @@ public class ConjurBuildStartContextProcessor implements BuildStartContextProces
             return;
         }
 
-        ConjurConnectionParameters conjurConfig = new ConjurConnectionParameters(connectionFeature.getParameters(), false);
+        ConjurConnectionParameters conjurConnParams = new ConjurConnectionParameters(connectionFeature.getParameters(), false);
 
         try {
-            for(Map.Entry<String, String> kv : conjurConfig.getAgentSharedParameters().entrySet()) {
+            for(Map.Entry<String, String> kv : conjurConnParams.getAgentSharedParameters().entrySet()) {
                 context.addSharedParameter(kv.getKey(), kv.getValue());
             }
         } catch (MissingMandatoryParameterException e) {
             BuildProblemData buildProblem = createBuildProblem(build,
                     String.format("ERROR: Setting agent's shared parameters. %s. %s",
-                            e.getMessage(), conjurConfig));
+                            e.getMessage(), conjurConnParams));
             build.addBuildProblem(buildProblem);
         }
     }

--- a/teamcity-server/src/main/java/com/cyberark/server/ConjurBuildStartContextProcessor.java
+++ b/teamcity-server/src/main/java/com/cyberark/server/ConjurBuildStartContextProcessor.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;
 
-
 import com.cyberark.common.*;
 
 public class ConjurBuildStartContextProcessor implements BuildStartContextProcessor {
@@ -32,7 +31,7 @@ public class ConjurBuildStartContextProcessor implements BuildStartContextProces
             return null;
         }
 
-        // If more than on connection was found return error
+        // If more than one connection was found return error
         if (connections.size() > 1 ) {
             throw new MultipleConnectionsReturnedException("Only one CyberArk Conjur Connection should be configured for this project.");
         }
@@ -70,7 +69,7 @@ public class ConjurBuildStartContextProcessor implements BuildStartContextProces
             return;
         }
 
-        ConjurConnectionParameters conjurConfig = new ConjurConnectionParameters(connectionFeature.getParameters());
+        ConjurConnectionParameters conjurConfig = new ConjurConnectionParameters(connectionFeature.getParameters(), false);
 
         try {
             for(Map.Entry<String, String> kv : conjurConfig.getAgentSharedParameters().entrySet()) {

--- a/teamcity-server/src/main/java/com/cyberark/server/ConjurBuildStartContextProcessor.java
+++ b/teamcity-server/src/main/java/com/cyberark/server/ConjurBuildStartContextProcessor.java
@@ -1,30 +1,21 @@
 package com.cyberark.server;
 
-import com.cyberark.common.exceptions.ConjurApiAuthenticateException;
 import com.cyberark.common.exceptions.MissingMandatoryParameterException;
 import com.cyberark.common.exceptions.MultipleConnectionsReturnedException;
 import jetbrains.buildServer.BuildProblemData;
 import jetbrains.buildServer.serverSide.*;
 import jetbrains.buildServer.serverSide.oauth.OAuthConstants;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManagerFactory;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.util.*;
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+
 
 import com.cyberark.common.*;
 
 public class ConjurBuildStartContextProcessor implements BuildStartContextProcessor {
 
-    // This method will return one SProjectFeatureDescriptior that represents the Cyberark Conjur Connection
+    // This method will return one SProjectFeatureDescriptor that represents the CyberArk Conjur Connection
     //   provided in the project Connections. This method will return null if no Connection can be found and will throw
     //   a MultipleConnectionsReturnedException if more than one connection was found.
     private SProjectFeatureDescriptor getConnectionType(SProject project, String providerType) throws MultipleConnectionsReturnedException {
@@ -59,27 +50,27 @@ public class ConjurBuildStartContextProcessor implements BuildStartContextProces
 
         SBuildType buildType = build.getBuildType();
         if (buildType == null) {
-            // It is possible of build type to be null, if this is the case lets return and not retrieve conjur secrets
+            // It is possible of build type to be null, if this is the case let's return and not retrieve conjur secrets
             return;
         }
 
         SProject project = buildType.getProject();
-        SProjectFeatureDescriptor connectionFeatures = null;
+        SProjectFeatureDescriptor connectionFeature = null;
 
         try {
-            connectionFeatures = getConnectionType(project, ConjurSettings.getFeatureType());
+            connectionFeature = getConnectionType(project, ConjurSettings.getFeatureType());
         } catch (MultipleConnectionsReturnedException e) {
             BuildProblemData buildProblem = createBuildProblem(build, String.format("ERROR: %s", e.getMessage()));
             build.addBuildProblem(buildProblem);
         }
         
-        if (connectionFeatures == null) {
+        if (connectionFeature == null) {
             // If connection feature cannot be found (no connection has been configured on this project)
             // then return and do not perform conjur secret retrieval actions
             return;
         }
 
-        ConjurConnectionParameters conjurConfig = new ConjurConnectionParameters(connectionFeatures.getParameters());
+        ConjurConnectionParameters conjurConfig = new ConjurConnectionParameters(connectionFeature.getParameters());
 
         try {
             for(Map.Entry<String, String> kv : conjurConfig.getAgentSharedParameters().entrySet()) {
@@ -88,7 +79,7 @@ public class ConjurBuildStartContextProcessor implements BuildStartContextProces
         } catch (MissingMandatoryParameterException e) {
             BuildProblemData buildProblem = createBuildProblem(build,
                     String.format("ERROR: Setting agent's shared parameters. %s. %s",
-                            e.getMessage(), conjurConfig.toString()));
+                            e.getMessage(), conjurConfig));
             build.addBuildProblem(buildProblem);
         }
     }

--- a/teamcity-server/src/main/java/com/cyberark/server/ConjurParametersProvider.java
+++ b/teamcity-server/src/main/java/com/cyberark/server/ConjurParametersProvider.java
@@ -21,7 +21,7 @@ public class ConjurParametersProvider extends AbstractBuildParametersProvider {
 
         while(it.hasNext()) {
             SProjectFeatureDescriptor desc = it.next();
-            // TODO: "Connection" probably should not be hardcoded. Also this connection is different in the hashi implemention
+            // TODO: "Connection" probably should not be hardcoded. Also this connection is different in the hashi implementation
             if (desc.getParameters().get(OAuthConstants.OAUTH_TYPE_PARAM).equals(ConjurSettings.getFeatureType())) {
                 return true;
             }
@@ -46,7 +46,7 @@ public class ConjurParametersProvider extends AbstractBuildParametersProvider {
 
         while(it.hasNext()) {
             SProjectFeatureDescriptor desc = it.next();
-            // TODO: "Connection" should probably not be hardedcoded. Also this connection is different in the hashi implemention
+            // TODO: "Connection" should probably not be hardcoded. Also this connection is different in the hashi implementation
             if (desc.getParameters().get(OAuthConstants.OAUTH_TYPE_PARAM).equals(ConjurSettings.getFeatureType())) {
                 connectionFeatures = desc;
                 break;
@@ -56,11 +56,6 @@ public class ConjurParametersProvider extends AbstractBuildParametersProvider {
         if (connectionFeatures == null) {
             return Collections.emptyList();
 		}
-
-        Map<String, String> conjurFeatures = connectionFeatures.getParameters();
-        Map<String, String> parameters = build.getBuildOwnParameters();
-
-        // exposed.add("SUPER_SECRET");
 
         return exposed;
     }

--- a/teamcity-server/src/main/java/com/cyberark/server/ConjurProjectConnectionProvider.java
+++ b/teamcity-server/src/main/java/com/cyberark/server/ConjurProjectConnectionProvider.java
@@ -1,13 +1,11 @@
 package com.cyberark.server;
 
 import com.cyberark.common.ConjurConnectionParameters;
-import com.cyberark.common.ConjurJspKey;
 import com.cyberark.common.ConjurSettings;
 import com.cyberark.common.exceptions.MissingMandatoryParameterException;
 import jetbrains.buildServer.serverSide.PropertiesProcessor;
 import jetbrains.buildServer.serverSide.oauth.OAuthProvider;
 import jetbrains.buildServer.serverSide.oauth.OAuthConnectionDescriptor;
-import java.util.Map;
 
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
 import org.jetbrains.annotations.NotNull;
@@ -43,11 +41,11 @@ public class ConjurProjectConnectionProvider extends OAuthProvider {
 	@Override
 	@NotNull
 	public String describeConnection(OAuthConnectionDescriptor connection) {
-		ConjurConnectionParameters parameters = new ConjurConnectionParameters(connection.getParameters());
+		ConjurConnectionParameters parameters = new ConjurConnectionParameters(connection.getParameters(), false);
 
 		String message = "NA";
 		try {
-			message = String.format("Connection to Cyberark Conjur server at '%s' with login '%s'",
+			message = String.format("Connection to CyberArk Conjur server at '%s' with login '%s'",
 					parameters.getApplianceUrl(), parameters.getAuthnLogin());
 		} catch (MissingMandatoryParameterException e) {
 			message = "Invalid Conjur Connection Configuration";

--- a/teamcity-server/src/main/java/com/cyberark/server/ConjurPropertiesProcessor.java
+++ b/teamcity-server/src/main/java/com/cyberark/server/ConjurPropertiesProcessor.java
@@ -30,7 +30,6 @@ public class ConjurPropertiesProcessor implements PropertiesProcessor {
                     "URL should start with 'https://' or 'http://'"));
         }
 
-
         // Validate Account
         String account = properties.get(conjurKeys.getAccount());
         if (isEmptyOrNull(account)) {


### PR DESCRIPTION
### Desired Outcome

Fixes issue #5. 

If there was no Conjur connection defined (on the project level), the builds were failing even though they didn't use any parameters referring to any Conjur instance. As a result, if the Conjur plugin was *enabled*, all the projects (or the _Root) project needed a Conjur connection defined, and all builds were creating a connection when starting, no matter if they needed it or not.

Also note that in some cases the project or TC server administrator does *not* want some projects/builds to access Conjur at all - this fix makes this scenario possible.

### Implemented Changes

No new code was added. Instead, I tried to simplify existing where possible, to provide more descriptive variable names, to make imports more specific, and to get rid of maven warnings.

The crucial fix is the one in the ```ConjurEnvParameterReplacer``` class (previously ```ConjurBuildFeature```) - the check for existence of any Conjur-related parameters in a build is performed *before* trying to access the Conjur connection parameters, not *after* it: here, the ```if {... }``` block is only moved a few lines above.

### Connected Issue/Story

Resolves #5, which is a blocker for even validating the plugin on a subproject on an existing TeamCity instance. Before the fix, the only way to run (or even test) this plugin was to create the connection on the Root project and/or on every single subproject.

### Definition of Done

#### Changelog

- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] The changes in this PR do not require tests

#### Documentation

- [x] This PR does not require updating any documentation

#### Behavior

- [x] No behavior was changed with this PR (it's just fixing the behavior so it does what the user expects).

#### Security

- [x] There are no security aspects to these changes (strictly speaking, a comment in the code highlights the existence of #7 - fixing it will be the next step)
