### PR TITLE
The connection details (the API key at least) must not be shown in plaintext 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,14 @@ To run unit tests execute the following:
 ```bash
 mvn test
 ```
+### Manual test scenarios
+
+Test setup: add and enable the Conjur TeamCity Plugin, create a project and an empty/dummy build inside
+* In a project that has no Conjur Connection defined:
+  * run the build - it must run the same way as if the Conjur TeamCity Plugin wasn't present/enabled
+* In a project that does have a Conjur Connection defined:
+  * run the build that has no Conjur-sourced parameter defined - the build must not create any Conjur connection (verify in verbose-level build log)
+  * run the build that has a Conjur-sourced parameter defined - the build must create the Conjur connection and must replace the parameter value with the one from Conjur (verify in verbose-level build log and in build parameters)
 
 ## Releases
 To create a new release in this project, follow the standard [release guidelines](https://github.com/cyberark/community/blob/master/Conjur/CONTRIBUTING.md#release-process).

--- a/teamcity-common/src/main/java/com/cyberark/common/ConjurConnectionParameters.java
+++ b/teamcity-common/src/main/java/com/cyberark/common/ConjurConnectionParameters.java
@@ -27,17 +27,18 @@ public class ConjurConnectionParameters {
         this.verboseLogging = parameters.get(prefix + conjurKeys.getVerboseLogging());
     }
 
-    public Map<String, String> getAgentSharedParameters() throws MissingMandatoryParameterException {
+    public Map<String, String> getAgentSharedParameters(boolean returnSecretParamsOnly) throws MissingMandatoryParameterException {
         HashMap<String, String> sharedParameters = new HashMap<>();
 
-        sharedParameters.put(agentParameterPrefix + conjurKeys.getAccount(), this.getAccount());
-        sharedParameters.put(agentParameterPrefix + conjurKeys.getApplianceUrl(), this.getApplianceUrl());
-        sharedParameters.put(agentParameterPrefix + conjurKeys.getAuthnLogin(), this.getAuthnLogin());
-        sharedParameters.put(agentParameterPrefix + conjurKeys.getApiKey(), this.getApiKey()); // TODO !!! this must be added as a password-type param instead, or must not be added at all
-        sharedParameters.put(agentParameterPrefix + conjurKeys.getCertFile(), this.getCertFile());
-        sharedParameters.put(agentParameterPrefix + conjurKeys.getFailOnError(), String.valueOf(this.getFailOnError()));
-        sharedParameters.put(agentParameterPrefix + conjurKeys.getVerboseLogging(), String.valueOf(this.getVerboseLogging()));
-
+        sharedParameters.put(agentParameterPrefix + conjurKeys.getApiKey(), this.getApiKey());
+        if (!returnSecretParamsOnly) {
+            sharedParameters.put(agentParameterPrefix + conjurKeys.getAccount(), this.getAccount());
+            sharedParameters.put(agentParameterPrefix + conjurKeys.getApplianceUrl(), this.getApplianceUrl());
+            sharedParameters.put(agentParameterPrefix + conjurKeys.getAuthnLogin(), this.getAuthnLogin());
+            sharedParameters.put(agentParameterPrefix + conjurKeys.getCertFile(), this.getCertFile());
+            sharedParameters.put(agentParameterPrefix + conjurKeys.getFailOnError(), String.valueOf(this.getFailOnError()));
+            sharedParameters.put(agentParameterPrefix + conjurKeys.getVerboseLogging(), String.valueOf(this.getVerboseLogging()));
+        }
         return sharedParameters;
     }
 

--- a/teamcity-common/src/main/java/com/cyberark/common/ConjurConnectionParameters.java
+++ b/teamcity-common/src/main/java/com/cyberark/common/ConjurConnectionParameters.java
@@ -6,13 +6,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ConjurConnectionParameters {
-    private String apiKey;
-    private String authnLogin;
-    private String applianceUrl;
-    private String account;
-    private String certFile;
-    private String failOnError;
-    private String verboseLogging;
+    private final String apiKey;
+    private final String authnLogin;
+    private final String applianceUrl;
+    private final String account;
+    private final String certFile;
+    private final String failOnError;
+    private final String verboseLogging;
     private static final ConjurJspKey conjurKeys = new ConjurJspKey();
     private static final String agentParameterPrefix = "teamcity.conjur.";
 
@@ -28,7 +28,7 @@ public class ConjurConnectionParameters {
     }
 
     public Map<String, String> getAgentSharedParameters() throws MissingMandatoryParameterException {
-        HashMap<String, String> sharedParameters = new HashMap<String, String>();
+        HashMap<String, String> sharedParameters = new HashMap<>();
 
         sharedParameters.put(agentParameterPrefix + conjurKeys.getAccount(), this.getAccount());
         sharedParameters.put(agentParameterPrefix + conjurKeys.getApplianceUrl(), this.getApplianceUrl());
@@ -52,41 +52,25 @@ public class ConjurConnectionParameters {
                 conjurKeys.getVerboseLogging(), this.verboseLogging);
     }
 
-    private boolean validateUrl(String url) {
-        if (url.startsWith("https://") || url.startsWith("http://")) {
-            return true;
-        }
-        return false;
-    }
-
-    private String trim(String input) {
+    private String trimMandatoryParameter(String input, String key) throws MissingMandatoryParameterException {
         if (input == null) {
-            return null;
+            throw new MissingMandatoryParameterException(String.format("Failed to retrieve mandatory parameter '%s'. This should not happen", key));
         }
         return input.trim();
     }
 
-    private String trimMandatoryParameter(String input, String key) throws MissingMandatoryParameterException {
-        input = trim(input);
-        if (input == null) {
-            throw new MissingMandatoryParameterException(String.format("Failed to retrieve mandatory parameter '%s'. This should not happen", key));
-        }
-        return input;
-    }
-
     private String trimOptionalParameter(String input) {
-        return trim(input);
+        if (input != null)
+            return input.trim();
+        else
+            return null;
     }
 
     private boolean isTrue(String str) {
         if (str == null) {
             return false;
         }
-        return str.trim().toLowerCase().equals("true");
-    }
-
-    public boolean isValidUrl() throws MissingMandatoryParameterException {
-        return this.validateUrl(this.getApplianceUrl());
+        return str.trim().equalsIgnoreCase("true");
     }
 
     public String getApplianceUrl() throws MissingMandatoryParameterException {
@@ -110,7 +94,7 @@ public class ConjurConnectionParameters {
         return trimMandatoryParameter(this.apiKey, conjurKeys.getApiKey());
     }
 
-    public String getCertFile(){
+    public String getCertFile() {
         String certContent = trimOptionalParameter(this.certFile);
         if (certContent == null) {
             certContent = "";
@@ -118,7 +102,7 @@ public class ConjurConnectionParameters {
         return certContent;
     }
 
-    public boolean getFailOnError(){
+    public boolean getFailOnError() {
         return isTrue(this.failOnError);
     }
 

--- a/teamcity-server/src/main/java/com/cyberark/server/ConjurBuildStartContextProcessor.java
+++ b/teamcity-server/src/main/java/com/cyberark/server/ConjurBuildStartContextProcessor.java
@@ -18,7 +18,7 @@ public class ConjurBuildStartContextProcessor implements BuildStartContextProces
     //   provided in the build's parent project Connections. This method will return null if no Connection can be found
     //   and will throw a MultipleConnectionsReturnedException if more than one connection was found.
     //   The convention is to only accept one and consider more as a configuration error.
-    private Map<String, String> getConjurConnectionParams(SBuild build, String providerType)
+    private Map<String, String> getConjurConnectionParams(SBuild build, String providerType, boolean returnSecretParamsOnly)
             throws MultipleConnectionsReturnedException, MissingMandatoryParameterException {
         SBuildType buildType = build.getBuildType();
         if (buildType == null) {
@@ -43,7 +43,7 @@ public class ConjurBuildStartContextProcessor implements BuildStartContextProces
 
         SProjectFeatureDescriptor connectionFeature = connections.get(0);
         ConjurConnectionParameters conjurConnParams = new ConjurConnectionParameters(connectionFeature.getParameters(), false);
-        return conjurConnParams.getAgentSharedParameters();
+        return conjurConnParams.getAgentSharedParameters(returnSecretParamsOnly);
     }
 
     private BuildProblemData createBuildProblem(SBuild build, String message) {
@@ -56,7 +56,7 @@ public class ConjurBuildStartContextProcessor implements BuildStartContextProces
 
         Map<String, String> conjurConnParams = null;
         try {
-            conjurConnParams = getConjurConnectionParams(build, ConjurSettings.getFeatureType());
+            conjurConnParams = getConjurConnectionParams(build, ConjurSettings.getFeatureType(), false);
         }
         catch (MultipleConnectionsReturnedException | MissingMandatoryParameterException e) {
             BuildProblemData buildProblem = createBuildProblem(build, String.format("ERROR: %s", e.getMessage()));

--- a/teamcity-server/src/main/java/com/cyberark/server/ConjurBuildStartContextProcessor.java
+++ b/teamcity-server/src/main/java/com/cyberark/server/ConjurBuildStartContextProcessor.java
@@ -16,10 +16,10 @@ import com.cyberark.common.*;
 
 public class ConjurBuildStartContextProcessor implements BuildStartContextProcessor, PasswordsProvider {
 
-    // This method will params that represents the CyberArk Conjur Connection
+    // This method will return params that represent the CyberArk Conjur Connection
     //   provided in the build's parent project Connections. This method will return null if no Connection can be found
     //   and will throw a MultipleConnectionsReturnedException if more than one connection was found.
-    //   The convention is to only accept one and consider more as a configuration error.
+    //   The convention is to only accept one connection, and to consider more connections as a (user's) configuration error.
     private Map<String, String> getConjurConnectionParams(SBuild build, String providerType, boolean returnSecretParamsOnly)
             throws MultipleConnectionsReturnedException, MissingMandatoryParameterException {
         SBuildType buildType = build.getBuildType();
@@ -71,7 +71,7 @@ public class ConjurBuildStartContextProcessor implements BuildStartContextProces
         }
     }
 
-    // the purpose of this method is to mark a given param as password-type
+    // the purpose of this method is to mark designated sensitive param(s) as password-type
     @Override
     public Collection<Parameter> getPasswordParameters(SBuild build) {
         Map<String, String> conjurConnParams = null;


### PR DESCRIPTION
### Desired Outcome

The server-side plugin code reads the Conjur Connection details and adds these properties into the build when it is started on the server. Then the agent-side plugin code reads those parameters, establishes a connection to Conjur, and uses it to read the secrets as necessary.
Unfortunately, the connection details remain in plaintext in the build's ```teamcity.conjur.*``` parameters, including the API key.
This means that anyone who happens to have access to any finished build (within a project that has the Conjur connection defined) can read the "master" key to secrets for the given login and the Conjur instance.
  
### Implemented Changes

The change in this PR means that the API key is no longer added as a regular (plain text) parameter but as a password-type parameter instead.

Please see the screenshots from the builds' parameters:
- before the fix:
<img width="444" alt="connection_params_before" src="https://user-images.githubusercontent.com/72375226/202846315-59707675-70f5-44e0-bd28-a9023084fd89.png">

- after the fix:
<img width="450" alt="connection_params_after" src="https://user-images.githubusercontent.com/72375226/202846326-255405ce-f286-4327-b147-9546211715b0.png">

### Connected Issue/Story

Resolves #7

### Definition of Done

#### Changelog

- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new manual tests

#### Documentation

- [x] Docs were updated in this PR - basic manual test cases were added to CONTRIBUTING.md.

#### Behavior

- [x] No behavior was changed with this PR

#### Security

- [x] These changes are part of a larger initiative with a separate security review
